### PR TITLE
fix: sets the etcd prefix to the instance.Name

### DIFF
--- a/internal/reconciler/config.go
+++ b/internal/reconciler/config.go
@@ -118,8 +118,8 @@ func (b *ConfigReconciler) newObject() (*corev1.ConfigMap, error) {
 		defaultConfig.Section("main").Key("consumer_timeout").SetValue(fmt.Sprintf("%d", b.Instance.Spec.Config.ConsumerTimeout))
 	}
 
-	// TODO: Add advertised uri may be wrong here. Headless service?
-	clusterConfig.Section("clustering").Key("advertised_uri").SetValue(fmt.Sprintf("tcp://%s:5679", b.Instance.Name))
+	// Sets the etcd-prefix config value to the instance name. Allows for multiple lavinmq clusters to share the same etcd cluster.
+	clusterConfig.Section("clustering").Key("etcd_prefix").SetValue(b.Instance.Name)
 
 	config := strings.Builder{}
 

--- a/internal/reconciler/config_test.go
+++ b/internal/reconciler/config_test.go
@@ -78,7 +78,7 @@ var _ = Describe("ConfigReconciler", func() {
 			enabled = true
 			bind = 0.0.0.0
 			port = 5679
-			advertised_uri = tcp://test-resource:5679
+			etcd_prefix = test-resource
 	`
 		It("Should create a default ConfigMap", func() {
 			rc.Reconcile(context.Background())
@@ -136,7 +136,7 @@ var _ = Describe("ConfigReconciler", func() {
 			enabled = true
 			bind = 0.0.0.0
 			port = 5679
-			advertised_uri = tcp://test-resource:5679
+			etcd_prefix = test-resource
 		`
 
 		It("Should setup ports in according section", func() {


### PR DESCRIPTION
fixes: #28