### PR TITLE
fix: Use explicit comparisons when working with resources.

### DIFF
--- a/internal/reconciler/statefulset.go
+++ b/internal/reconciler/statefulset.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"lavinmq-operator/internal/controller/utils"
+	resource_utils "lavinmq-operator/internal/reconciler/utils"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -259,7 +260,7 @@ func (b *StatefulSetReconciler) diffTemplate(old *corev1.PodSpec) {
 		oldContainer.Image = b.Instance.Spec.Image
 	}
 
-	if !reflect.DeepEqual(oldContainer.Resources, b.Instance.Spec.Resources) {
+	if !resource_utils.EqualResourceRequirements(oldContainer.Resources, b.Instance.Spec.Resources) {
 		b.Logger.Info("Container resources changed, updating")
 		oldContainer.Resources = b.Instance.Spec.Resources
 	}

--- a/internal/reconciler/utils/resource_utils.go
+++ b/internal/reconciler/utils/resource_utils.go
@@ -1,0 +1,33 @@
+package resource_utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// equalResourceRequirements compares two ResourceRequirements objects using the Cmp method for each resource
+func EqualResourceRequirements(a, b corev1.ResourceRequirements) bool {
+	// Compare Requests
+	if !equalResourceLists(a.Requests, b.Requests) {
+		return false
+	}
+
+	// Compare Limits
+	if !equalResourceLists(a.Limits, b.Limits) {
+		return false
+	}
+
+	return true
+}
+
+func equalResourceLists(a, b corev1.ResourceList) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, exists := b[k]; !exists || v.Cmp(bv) != 0 {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
The reflect.DeepEqual seems to not work as expected when comparing items that are fetched from the k8cluster. I believe the reason is that the k8cluster is adding some additional metadata to items in the cluster while we compare it to a raw resource request.

I noticed that this may be the case when trying to create a cluster and `Container resources changed, updating` was written to the logs on every new "event" to the operator. With these changes, I do not see this log entry any more. 