### PR TITLE
fix: Adds retry on conflict to STS updates.

### DIFF
--- a/internal/reconciler/statefulset.go
+++ b/internal/reconciler/statefulset.go
@@ -44,7 +44,7 @@ func (b *StatefulSetReconciler) Reconcile(ctx context.Context) (ctrl.Result, err
 
 		err = b.Client.Update(ctx, statefulset)
 		if err != nil {
-                         b.Logger.Error("Failed updating statefulset something something, trying again?")
+			b.Logger.Error(err, "Failed updating statefulset something something, trying again?")
 			return err
 		}
 


### PR DESCRIPTION
When some changes occur to items that will force a STS update under the hood, there may become a version mismatch between the k8 state and the state in our controller. Adding this retry logic will cause the STS to be refetched prior to making the actual changes to STS that we want to.

fixes #41