### PR TITLE
BUGFIX - exposing clustering advertised port

### DIFF
--- a/config/samples/cloudamqp.com_v1alpha1_lavinmq.yaml
+++ b/config/samples/cloudamqp.com_v1alpha1_lavinmq.yaml
@@ -38,6 +38,5 @@ spec:
       channel_max: 100
     mqtt:
       max_inflight_messages: 100
-      port: -1
     clustering:
       max_unsynced_actions: 8192

--- a/internal/reconciler/statefulset.go
+++ b/internal/reconciler/statefulset.go
@@ -198,7 +198,7 @@ func (b *StatefulSetReconciler) cliArgs() []string {
 	if b.Instance.Spec.Replicas > 0 {
 		// Clustering config is currently spread between CLI here and in the config file.
 		clusteringArgs := []string{
-			fmt.Sprintf("--clustering-advertised-uri=tcp://$(POD_NAME).%s-service.$(POD_NAMESPACE).svc.cluster.local:5679", b.Instance.Name),
+			fmt.Sprintf("--clustering-advertised-uri=tcp://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:5679", b.Instance.Name),
 		}
 		defaultArgs = append(defaultArgs, clusteringArgs...)
 	}


### PR DESCRIPTION
Headless service naming is not postfixed with `-service` anymore.

Also change config example from disabling mqtt port