### PR TITLE
Clarify how to install operator for endusers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can apply the samples (examples) from the config/sample:
 kubectl apply -k config/samples/
 ```
 
->**NOTE**: Ensure that the samples has default values to test it out. For ETCD example to work, you also need to install the ETCD operator
+>**NOTE**: Ensure that the samples have default values to test it out. For ETCD example to work, you also need to install the ETCD operator
 
 ### To Uninstall
 **Undeploy the controller from the cluster:**


### PR DESCRIPTION
fixes #59 

Readme instructions focused to much on development instruction of how to deploy. Lets lift and promote the intended end-user deployment strategy.