### PR TITLE
live and readiness command to not fail on followers

### DIFF
--- a/internal/reconciler/statefulset.go
+++ b/internal/reconciler/statefulset.go
@@ -144,7 +144,7 @@ func (b *StatefulSetReconciler) appendSpec(sts *appsv1.StatefulSet) *appsv1.Stat
 						StartupProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								Exec: &corev1.ExecAction{
-									Command: []string{"/usr/bin/lavinmqctl", "status"},
+									Command: []string{"/bin/sh", "-c", "/usr/bin/lavinmqctl status || /usr/bin/lavinmqctl status | grep -q follower"},
 								},
 							},
 							FailureThreshold: 30,
@@ -153,7 +153,7 @@ func (b *StatefulSetReconciler) appendSpec(sts *appsv1.StatefulSet) *appsv1.Stat
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								Exec: &corev1.ExecAction{
-									Command: []string{"/usr/bin/lavinmqctl", "status"},
+									Command: []string{"/bin/sh", "-c", "/usr/bin/lavinmqctl status || /usr/bin/lavinmqctl status | grep -q follower"},
 								},
 							},
 							PeriodSeconds: 10,
@@ -161,7 +161,7 @@ func (b *StatefulSetReconciler) appendSpec(sts *appsv1.StatefulSet) *appsv1.Stat
 						ReadinessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								Exec: &corev1.ExecAction{
-									Command: []string{"/usr/bin/lavinmqctl", "status"},
+									Command: []string{"/bin/sh", "-c", "/usr/bin/lavinmqctl status || /usr/bin/lavinmqctl status | grep -q follower"},
 								},
 							},
 							InitialDelaySeconds: 5,


### PR DESCRIPTION
PR created on the back of comment in https://github.com/cloudamqp/lavinmq-operator/issues/49#issuecomment-3148826483
When clustering, follower nodes does not return exit code 0 when using lavinmqctl status. this ensures nodes are marked ready and alive. 

after making changes I tested using `make build-install`, applied the install.yaml, and `make run`. Looks like it's working.
